### PR TITLE
Fixed javadoc to avoid exposing internal schemes/protocols.

### DIFF
--- a/api/src/main/java/org/kaazing/net/URLFactory.java
+++ b/api/src/main/java/org/kaazing/net/URLFactory.java
@@ -40,7 +40,7 @@ import java.util.ServiceLoader;
  * protocols such as
  * <p/>
  * {@code
- * ws, wse, wsn, wss, wse+ssl
+ * ws, wss
  * }
  * <p/>
  * like this:


### PR DESCRIPTION
Internal schemes used for emulation should not be exposed.
