### PR TITLE
Added checks for empty/null enabled extensions and protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ out
 *.sublime-workspace
 build-local.properties
 .gradle
+.checkstyle
 

--- a/ws/README.md
+++ b/ws/README.md
@@ -45,8 +45,8 @@ Using the following maven dependency, developers can include netx.ws to develop 
 
 ### Steps for building this project
 
-0. Clone the repo: ```git clone https://github.com/kaazing/netx.ws.git```
-0. Go to the cloned directory: ```cd netx.ws```
+0. Clone the repo: ```git clone https://github.com/kaazing/netx.git```
+0. Go to the cloned directory: ```cd netx```
 0. Build the project: ```mvn clean install```
 
 ## Target JVM Version - Java SE 1.6
@@ -68,7 +68,7 @@ netx.ws offers `org.kaazing.netx.ws.WebSocketFactory` to create instances of `or
 
  ``` java
  WebSocketFactory factory = WebSocketFactory.newInstance();
- WebSocket connection = factory.createWebSocket(URI.toString("http://echo.websocket.org"));
+ WebSocket connection = factory.createWebSocket(URI.toString("ws://echo.websocket.org"));
  ```
 ### org.kaazing.netx.ws.WsURLConnection
 
@@ -101,7 +101,7 @@ The following code illustrates streaming in binary payload without being aware o
 
 ``` java
 WebSocketFactory factory = WebSocketFactory.newInstance();
-WebSocket connection = factory.createWebSocket(URI.toString("http://echo.websocket.org"));
+WebSocket connection = factory.createWebSocket(URI.toString("ws://echo.websocket.org"));
 InputStream in = connection.getInputStream();
 
 byte[] buf = new byte[125];
@@ -297,7 +297,7 @@ The following code illustrates sending a binary message that fits in a single We
 
 ``` java
 WebSocketFactory factory = WebSocketFactory.newInstance();
-WebSocket connection = factory.createWebSocket(URI.create("http://echo.websocket.org"));
+WebSocket connection = factory.createWebSocket(URI.create("ws://echo.websocket.org"));
 MessageWriter messageWriter = connection.getMessageWriter();
 byte[] bytes = new byte[125];
 Random random = new Random();

--- a/ws/src/main/java/org/kaazing/netx/ws/internal/WebSocketImpl.java
+++ b/ws/src/main/java/org/kaazing/netx/ws/internal/WebSocketImpl.java
@@ -53,7 +53,9 @@ public class WebSocketImpl extends WebSocket {
 
     @Override
     public void addEnabledExtensions(String... extensions) {
-        connection.addEnabledExtensions(extensions);
+        if (extensions.length > 0) {
+            connection.addEnabledExtensions(extensions);
+        }
     }
 
     @Override
@@ -111,10 +113,12 @@ public class WebSocketImpl extends WebSocket {
         return connection.getMaxFramePayloadLength();
     }
 
+    @Override
     public MessageReader getMessageReader() throws IOException {
         return connection.getMessageReader();
     }
 
+    @Override
     public MessageWriter getMessageWriter() throws IOException {
         return connection.getMessageWriter();
     }

--- a/ws/src/main/java/org/kaazing/netx/ws/internal/WsURLConnectionImpl.java
+++ b/ws/src/main/java/org/kaazing/netx/ws/internal/WsURLConnectionImpl.java
@@ -327,6 +327,7 @@ public final class WsURLConnectionImpl extends WsURLConnection {
         }
     }
 
+    @Override
     public WsMessageReader getMessageReader() throws IOException {
         if (messageReader != null) {
             return messageReader;
@@ -348,6 +349,7 @@ public final class WsURLConnectionImpl extends WsURLConnection {
         }
     }
 
+    @Override
     public WsMessageWriter getMessageWriter() throws IOException {
         if (messageWriter != null) {
             return messageWriter;
@@ -483,7 +485,10 @@ public final class WsURLConnectionImpl extends WsURLConnection {
         try {
             stateLock.lock();
             this.enabledProtocols.clear();
-            this.enabledProtocols.addAll(Arrays.asList(enabledProtocols));
+
+            if (enabledProtocols != null) {
+                this.enabledProtocols.addAll(Arrays.asList(enabledProtocols));
+            }
         }
         finally {
             stateLock.unlock();

--- a/ws/src/main/java/org/kaazing/netx/ws/internal/io/WsInputStream.java
+++ b/ws/src/main/java/org/kaazing/netx/ws/internal/io/WsInputStream.java
@@ -306,7 +306,7 @@ public final class WsInputStream extends InputStream {
         }
 
         assert applicationBufferReadOffset < applicationBufferWriteOffset;
-        return applicationBuffer[applicationBufferReadOffset++];
+        return applicationBuffer[applicationBufferReadOffset++] & 0xFF;
     }
 
     private boolean isControlFrame() {

--- a/ws/src/test/java/org/kaazing/netx/ws/factory/WebSocketFactoryTest.java
+++ b/ws/src/test/java/org/kaazing/netx/ws/factory/WebSocketFactoryTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.netx.ws.factory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+import org.kaazing.netx.ws.WebSocket;
+import org.kaazing.netx.ws.WebSocketFactory;
+
+public class WebSocketFactoryTest {
+    public WebSocketFactoryTest() {
+    }
+
+    @Test
+    public void testWebSocketCreation() {
+        WebSocketFactory factory = WebSocketFactory.newInstance();
+        try {
+            WebSocket ws = factory.createWebSocket(URI.create("ws://echo.websocket.org"));
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/ws/src/test/java/org/kaazing/netx/ws/factory/WebSocketFactoryTest.java
+++ b/ws/src/test/java/org/kaazing/netx/ws/factory/WebSocketFactoryTest.java
@@ -27,12 +27,8 @@ public class WebSocketFactoryTest {
     }
 
     @Test
-    public void testWebSocketCreation() {
+    public void testWebSocketCreation() throws URISyntaxException {
         WebSocketFactory factory = WebSocketFactory.newInstance();
-        try {
-            WebSocket ws = factory.createWebSocket(URI.create("ws://echo.websocket.org"));
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
+        WebSocket ws = factory.createWebSocket(URI.create("ws://echo.websocket.org"));
     }
 }


### PR DESCRIPTION
while creating the WebSocket object from  the factory. Also, fixed WsInputStream.readInternal() mask the byte before returning it.
