### PR TITLE
Added package-info so there would be javadoc generated, unfortunately…

### DIFF
--- a/data/src/main/java/org/kaazing/netx/data/Dummy.java
+++ b/data/src/main/java/org/kaazing/netx/data/Dummy.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.netx.data;
+
+/**
+ * This project has no public api.  This class is only here to get javadoc to compile, as required for Sonatype.
+ */
+public class Dummy {
+
+}

--- a/data/src/main/java/org/kaazing/netx/data/package-info.java
+++ b/data/src/main/java/org/kaazing/netx/data/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This project has no public api.
+ */
+package org.kaazing.netx.data;

--- a/http.bridge/bridge/src/main/java/org/kaazing/netx/http/bridge/Dummy.java
+++ b/http.bridge/bridge/src/main/java/org/kaazing/netx/http/bridge/Dummy.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.netx.http.bridge;
+
+/**
+ * This project has no public api.  This class is only here to get javadoc to compile, as required for Sonatype.
+ */
+public class Dummy {
+
+}

--- a/http.bridge/bridge/src/main/java/org/kaazing/netx/http/bridge/package-info.java
+++ b/http.bridge/bridge/src/main/java/org/kaazing/netx/http/bridge/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This project has no public api.
+ */
+package org.kaazing.netx.http.bridge;

--- a/http.bridge/itest/src/main/java/org/kaazing/netx/http/bridge/itest/Dummy.java
+++ b/http.bridge/itest/src/main/java/org/kaazing/netx/http/bridge/itest/Dummy.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.netx.http.bridge.itest;
+
+/**
+ * This project has no public api.  This class is only here to get javadoc to compile, as required for Sonatype.
+ */
+public class Dummy {
+
+}

--- a/http.bridge/itest/src/main/java/org/kaazing/netx/http/bridge/itest/package-info.java
+++ b/http.bridge/itest/src/main/java/org/kaazing/netx/http/bridge/itest/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This project has no public api.
+ */
+package org.kaazing.netx.http.bridge.itest;

--- a/tcp/src/main/java/org/kaazing/netx/tcp/Dummy.java
+++ b/tcp/src/main/java/org/kaazing/netx/tcp/Dummy.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.netx.tcp;
+
+/**
+ * This project has no public api.  This class is only here to get javadoc to compile, as required for Sonatype.
+ */
+public class Dummy {
+
+}

--- a/tcp/src/main/java/org/kaazing/netx/tcp/package-info.java
+++ b/tcp/src/main/java/org/kaazing/netx/tcp/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This project has no public api.
+ */
+package org.kaazing.netx.tcp;


### PR DESCRIPTION
… this is not sufficient as there is javadoc maven plugin wants to see at least one real class, so I've also added a Dummy.java javadoc